### PR TITLE
Fixer-upper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.nyc_output
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 
 node_js:
-  - "0.8"
   - "0.10"

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ var MyError = fasterror('MyError', {code: 'ENOENT'});
 
 `fasterror()` is the factory for creating custom error objects. The first
 argument is the name of the desired custom error object. The second is an object
-containing keys that will decoate any errors created with the resulting object.
+containing keys that will decorate any errors created with the resulting object.
 
 ```
-var err = new MyError('Failed to load user', {reason: 'missing', code: 2});
+var username = 'jsmith';
+var err = new MyError('Failed to load user %s', username);
 ```
 
-Create new errors with the resulting object. The first argument is the error
-message. The second is an object containing keys that will decorate the error,
-overriding any keys set by the factory.
+Create new errors with the resulting class. The error created will perform string
+interpolation on the arguments passed and set the resulting value as `err.message`.
+See [node.js documentation](https://nodejs.org/docs/v0.10.40/api/util.html#util_util_format_format)
+for interpolation details.

--- a/index.js
+++ b/index.js
@@ -1,22 +1,25 @@
-var _ = require('underscore');
+var util = require('util');
 
-module.exports = function(type, defaults) {
-    if (typeof defaults === 'string' ||
-        typeof defaults === 'number') defaults = { code: defaults };
+module.exports = fastErrorFactory;
 
-    function FastError(message, options) {
-    if (typeof options === 'string' ||
-        typeof options === 'number') options = { code: options };
-      Error.call(this);
-      Error.captureStackTrace(this, arguments.callee);
+function fastErrorFactory(name, defaults) {
+  function FastError() {
+    this.message = util.format.apply(null, arguments);
+    this.name = name;
+    Error.captureStackTrace(this, arguments.callee);
+  }
 
-      this.name = type;
-      this.constructor.name = type;
-      this.message = message || '';
+  FastError.prototype = Object.create(Error.prototype, {
+    constructor: { value: FastError }
+  });
 
-      _(this).chain().extend(defaults).extend(options);
+  if (typeof defaults === 'string' || typeof defaults === 'number') {
+    FastError.prototype.code = defaults
+  } else if (typeof defaults === 'object') {
+    for (var key in defaults) {
+      FastError.prototype[key] = defaults[key];
     }
-    FastError.prototype.__proto__ = Error.prototype;
+  }
 
-    return FastError;
-};
+  return FastError;
+}

--- a/package.json
+++ b/package.json
@@ -7,15 +7,13 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "nyc tape test/*.js"
   },
   "repository": "",
   "author": "Will White <will@mapbox.com>",
   "license": "BSD",
   "devDependencies": {
-    "mocha": "~1.17.1"
-  },
-  "dependencies": {
-    "underscore": "~1.5.2"
+    "nyc": "^3.2.2",
+    "tape": "^4.2.2"
   }
 }

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,69 +1,59 @@
-var assert = require('assert');
 var fasterror = require('../index');
+var test = require('tape');
 
-describe('error factory', function() {
-    it('should make an error constructor', function() {
-        var MyError = fasterror('MyError', 'code');
-        assert.equal(typeof MyError, 'function');
-    });
+test('[error factory] should make an error constructor', function(assert) {
+    var MyError = fasterror('MyError', { code: 'code' });
+    assert.equal(typeof MyError, 'function');
+    assert.end();
 });
 
-describe('error constructor', function() {
-    it('should make a error object that works with instanceof and typeof', function() {
-        var MyError = fasterror('MyError', 'code');
-        var err = new MyError();
-        assert(err instanceof MyError);
-        assert(err instanceof Error);
-        assert.equal(typeof err, 'object');
-    });
-    it('should set .name and .message properly', function() {
-        var MyError = fasterror('MyError', 'code');
-        var err = new MyError('test');
-        assert.equal(err.name, 'MyError');
-        assert.equal(err.message, 'test');
-    });
-    it('should set default properties from second argument if it is an object', function() {
-        var MyError = fasterror('MyError', {code: 123, foo: 'bar'});
-        var err = new MyError();
-        assert.equal(err.code, 123);
-        assert.equal(err.foo, 'bar');
-    });
-    it('should set default code if second argument is a string', function() {
-        var MyError = fasterror('MyError', 'ENOENT');
-        var err = new MyError();
-        assert.equal(err.code, 'ENOENT');
-    });
-    it('should set default code if second argument is a number', function() {
-        var MyError = fasterror('MyError', 123);
-        var err = new MyError();
-        assert.equal(err.code, 123);
-    });
+
+test('[error constructor] should make a error object that works with instanceof and typeof', function(assert) {
+    var MyError = fasterror('MyError', { code: 'code' });
+    var err = new MyError();
+    assert.ok(err instanceof MyError);
+    assert.ok(err instanceof Error);
+    assert.equal(typeof err, 'object');
+    assert.end();
+});
+test('[error constructor] should set .name and .message properly', function(assert) {
+    var MyError = fasterror('MyError', { code: 'code' });
+    var err = new MyError('test');
+    assert.equal(err.name, 'MyError');
+    assert.equal(err.message, 'test');
+    assert.end();
+});
+test('[error constructor] should set default properties from second argument if it is an object', function(assert) {
+    var MyError = fasterror('MyError', {code: 123, foo: 'bar'});
+    var err = new MyError();
+    assert.equal(err.code, 123);
+    assert.equal(err.foo, 'bar');
+    assert.end();
+});
+test('[error constructor] should set default code if second argument is a string', function(assert) {
+    var MyError = fasterror('MyError', 'ENOENT');
+    var err = new MyError();
+    assert.equal(err.code, 'ENOENT');
+    assert.end();
+});
+test('[error constructor] should set default code if second argument is a number', function(assert) {
+    var MyError = fasterror('MyError', 123);
+    var err = new MyError();
+    assert.equal(err.code, 123);
+    assert.end();
 });
 
-describe('error object', function() {
-    it('should set properties from second argument if it is an object', function() {
-        var MyError = fasterror('MyError', {code: 123});
-        var err = new MyError();
-        assert.equal(err.code, 123);
-    });
-    it('should set code if second argument is a string', function() {
-        var MyError = fasterror('MyError');
-        var err = new MyError('test', 'ENOENT');
-        assert.equal(err.code, 'ENOENT');
-    });
-    it('should set code if second argument is a number', function() {
-        var MyError = fasterror('MyError');
-        var err = new MyError('test', 123);
-        assert.equal(err.code, 123);
-    });
-    it('should merge with defaults from constructor', function() {
-        var MyError = fasterror('MyError', {code: 123, foo: 'bar'});
-        var err = new MyError('test', 'ENOENT');
-        assert.equal(err.code, 'ENOENT');
-        assert.equal(err.foo, 'bar');
-        var err2 = new MyError('test', {foo: 'baz', bar: 'bin'});
-        assert.equal(err2.code, 123);
-        assert.equal(err2.foo, 'baz');
-        assert.equal(err2.bar, 'bin');
-    });
+test('[error object] should perform string interpolation on provided arguments', function(assert) {
+    var MyError = fasterror('MyError');
+    var err = new MyError('%s, %j', 'bacon', { lettuce: true, tomato: true });
+    assert.equal(err.message, 'bacon, {"lettuce":true,"tomato":true}');
+    assert.end();
+});
+
+test('[error object] should merge with defaults from constructor', function(assert) {
+    var MyError = fasterror('MyError', {code: 123, foo: 'bar'});
+    var err = new MyError('test');
+    assert.equal(err.code, 123);
+    assert.equal(err.foo, 'bar');
+    assert.end();
 });


### PR DESCRIPTION
- Drops constructor functionality that would set properties on error instances, preserves the ability to set defaults when you create the class in the first place.
- Avoids use of `__proto__`.
- Switches tests to tape
- Drops underscore dependency

cc @willwhite 
