### PR TITLE
Allow extending error object from other types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nyc_output
 coverage
+node_modules

--- a/index.js
+++ b/index.js
@@ -2,14 +2,22 @@ var util = require('util');
 
 module.exports = fastErrorFactory;
 
-function fastErrorFactory(name, defaults) {
+function fastErrorFactory(name, defaults, Parent) {
   function FastError() {
     this.message = util.format.apply(null, arguments);
     this.name = name;
+    if (typeof Parent === 'function') {
+      Parent.apply(this, arguments);
+    }
     Error.captureStackTrace(this, arguments.callee);
   }
 
-  FastError.prototype = Object.create(Error.prototype, {
+  if (typeof defaults === 'function') {
+    Parent = defaults;
+    defaults = undefined;
+  }
+
+  FastError.prototype = Object.create((Parent || Error).prototype, {
     constructor: { value: FastError }
   });
 

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -57,3 +57,13 @@ test('[error object] should merge with defaults from constructor', function(asse
     assert.equal(err.foo, 'bar');
     assert.end();
 });
+
+test('[error object] should be an instanceof the parent Error', function(assert) {
+    var MyError = fasterror('MyError');
+    var MyNestedError = fasterror('MyNestedError', MyError);
+    var err = new MyNestedError();
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof MyError);
+    assert.ok(err instanceof MyNestedError);
+    assert.end();
+});


### PR DESCRIPTION
The fasterror method now accepts a third argument which is the
constructor to inherit from. By default, Error is used as the parent
type. The constructor is invoked with the error context and arguments.
