### PR TITLE
Allow passing an error into the fasterror constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,15 @@ module.exports = fastErrorFactory;
 
 function fastErrorFactory(name, defaults) {
   function FastError() {
-    this.message = util.format.apply(null, arguments);
     this.name = name;
-    Error.captureStackTrace(this, arguments.callee);
+
+    if (arguments[0] && arguments[0] instanceof Error) {
+      this.message = arguments[0].message;
+      this.stack = arguments[0].stack.replace(arguments[0].name, name);
+    } else {
+      this.message = util.format.apply(null, arguments);
+      Error.captureStackTrace(this, arguments.callee);
+    }
   }
 
   FastError.prototype = Object.create(Error.prototype, {

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -47,7 +47,7 @@ test('[error constructor] should copy message and stack from constructing error'
     var sourceErr = new TypeError('bad type');
     var err = new MyError(sourceErr);
     assert.equal(err.message, 'bad type');
-    assert.ok(err.stack.match(/^MyError: bad type\n    at Test.<anonymous>/));
+    assert.ok(err.stack.match(/^MyError: bad type/));
     // Is set to 47:21 to indicate it came from the `TypeError` line
     assert.ok(err.stack.match(/error.test.js:47:21/));
     assert.end();

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -42,6 +42,24 @@ test('[error constructor] should set default code if second argument is a number
     assert.equal(err.code, 123);
     assert.end();
 });
+test('[error constructor] should copy message and stack from constructing error', function(assert) {
+    var MyError = fasterror('MyError');
+    var sourceErr = new TypeError('bad type');
+    var err = new MyError(sourceErr);
+    assert.equal(err.message, 'bad type');
+    assert.ok(err.stack.match(/^MyError: bad type\n    at Test.<anonymous>/));
+    // Is set to 47:21 to indicate it came from the `TypeError` line
+    assert.ok(err.stack.match(/error.test.js:47:21/));
+    assert.end();
+});
+test('[error constructor] should set default code for constructing error', function(assert) {
+    var MyError = fasterror('MyError', {code: 'code'});
+    var sourceErr = new TypeError('bad type');
+    var err = new MyError(sourceErr);
+    assert.equal(err.message, 'bad type');
+    assert.equal(err.code, 'code');
+    assert.end();
+});
 
 test('[error object] should perform string interpolation on provided arguments', function(assert) {
     var MyError = fasterror('MyError');


### PR DESCRIPTION
Hi @willwhite @rclark, my name's Jake and I was hoping you could take a look at something that would be very nice for me.

When creating a library that interacts with other upstream libraries (such as the aws-sdk) I've found myself wanting to create a fasterror class to describe all of these errors, but don't want to lose the stacktrace from those errors, which could be useful in debugging.

With this PR, you could do something like:

``` JavaScript
var AWSError = fasterror('AWSError');

module.exports.get = function(key, callback) {
    s3.getObject(key, function(err, data) {
        if (err) return callback(new AWSError(err));
        ...
    });
});
```

And still see the internal stacktrace of the `err` as it was returned from `s3.getObject`.

Please let me know if you like this PR.

Jake
